### PR TITLE
Add .gitignore file to project directory

### DIFF
--- a/Seraphimdroid/.gitignore
+++ b/Seraphimdroid/.gitignore
@@ -1,0 +1,37 @@
+#built application files
+*.apk
+*.ap_
+
+# files for the dex VM
+*.dex
+
+# Java class files
+*.class
+
+# generated files
+bin/
+gen/
+
+# Local configuration file (sdk path, etc)
+local.properties
+
+# Windows thumbnail db
+Thumbs.db
+
+# OSX files
+.DS_Store
+
+# Eclipse project files
+.classpath
+.project
+
+# Android Studio
+*.iml
+/.idea/libraries
+.idea/workspace.xml
+
+.gradle
+build/
+
+#NDK
+obj/


### PR DESCRIPTION
This commit adds a .gitignore file to the Seraphomdroid subdir in order
to avoid versioning unnecessary files. In addition to this commit, it
would also be nice to remove the following files from the repository
(note that all the files are under the Seraphimdroid subdirectory):
- Thumbs.db
- .classpath
- .project
- .idea/libraries
- .idea/workspace.xml
- .gradle
- build/
